### PR TITLE
Update moduleInit.R to check env for modulecmd

### DIFF
--- a/R/moduleInit.R
+++ b/R/moduleInit.R
@@ -12,7 +12,7 @@ moduleInit <- function( version = '3.2.10',
 
   # Check if modulecmd exists in the bin directory of modulesHome
   module_cmd <- file.path(modulesHome, "bin", "modulecmd")
-  if(!file.exists(module_cmd)){
+  if(!file.exists(module_cmd) && Sys.which("modulecmd") == ""){
     stop(module_cmd, " missing!\n",
          "  Module environment init failed!" )
   }


### PR DESCRIPTION
Fail only if `modulecmd` is not in the installation tree and not on the `PATH`.

----
## Motivation
In RHEL9, `modulecmd` is not contained within the installation tree at `MODULESHOME/bin/modulecmd`, but is on the `PATH` at `/usr/bin/modulecmd`.

It seems wrong to `moduleInit(modulesHome='/usr'` when `MODULESHOME=/usr/share/modules`, even though this works.

## Solution
One possible solution is to test for `modulecomd` in the env if it is not found at `MODULESHOME/bin/modulecmd`.

## Foreseen Consequences
Possible issues where the `modulecmd` binary and installation mismatch, when multiple installations of Environment Modules exist on the same system, depending on how `PATH` is managed.